### PR TITLE
uwuw atom keyword

### DIFF
--- a/mcnp2cad.cpp
+++ b/mcnp2cad.cpp
@@ -154,9 +154,18 @@ protected:
     std::string ret;
     std::stringstream formatter;
     if(Gopt.uwuw_names){
+      bool mass_density = false;
+      if (rho <= 0){
+        mass_density = true;
+        rho = -rho;
+      }
       char rho_formatted [50];
       sprintf(rho_formatted, "%E", rho);
-      formatter << "mat:m" << mat << "/rho:" << rho_formatted;
+      formatter << "mat:m" << mat;
+      if(mass_density)
+          formatter << "/rho:" <<rho_formatted;
+      else
+          formatter << "/atom:" << rho_formatted;
     }
     else
       formatter << "mat_" << mat << "_rho_" << rho;

--- a/tests/INP-densities
+++ b/tests/INP-densities
@@ -1,0 +1,10 @@
+A input file with both mass and atom densities
+1 1 0.05 -1
+2 2 -2.0 1 -2
+3 0 2
+
+1 so 1
+2 so 2
+
+m1 1001 1
+m2 2004 2


### PR DESCRIPTION
Per discussion with @makeclean today, this PR modifies the -U flag to support atom and mass density specification via the `rho` and nascent `atom` keywords.