### PR TITLE
Build updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ help:
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
-gh-clean gh-revert clean:
+gh-clean gh-revert:
 	-rm -rf $(GHBUILDDIR)
 
 gh-preview html:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 #
 # CGM_BASE_DIR = /path/to/installed/cgm
 
-include ${CGM_BASE_DIR}/lib/iGeom-Defs.inc
+-include ${CGM_BASE_DIR}/lib/iGeom-Defs.inc
 
 
 CXXSOURCES = mcnp2cad.cpp MCNPInput.cpp volumes.cpp geometry.cpp ProgOptions.cpp


### PR DESCRIPTION
This addresses both #17 and #18. 

One correction to target names and an update to the CGM_BASE_DIR include command for the CGM libraries s.t. it will silently fail if unsuccessful. Build will still fail due to missing CGM/iGeom libraries if CGM_BASE_DIR command is set improperly. 

