### PR TITLE
Doc update for GQ additions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 # prompt%> make CGM_BASE_DIR=/path/to/installed/cgm
 #
 # CGM_BASE_DIR = /path/to/installed/cgm
+# ARMADILLO_BASE_DIR = /path/to/installed/armadillo
 
 -include ${CGM_BASE_DIR}/lib/iGeom-Defs.inc
 
@@ -16,11 +17,11 @@ CXXSOURCES = mcnp2cad.cpp MCNPInput.cpp volumes.cpp geometry.cpp ProgOptions.cpp
 CXXOBJS = mcnp2cad.o MCNPInput.o volumes.o geometry.o ProgOptions.o
 
 # Remove HAVE_IGEOM_CONE from the next line if using old iGeom implementation
-CXXFLAGS = -g -std=c++11 -Wall -Wextra -DUSING_CGMA -DHAVE_IGEOM_CONE
+CXXFLAGS = -g -std=c++11 -Wall -Wextra -DUSING_CGMA -DHAVE_IGEOM_CONE -I${ARMADILLO_BASE_DIR}/include
 
 
 LDFLAGS = ${IGEOM_LIBS} 
-LDFLAGS += -larmadillo
+LDFLAGS += -L${ARMADILLO_BASE_DIR}/lib -larmadillo
 
 mcnp2cad: ${CXXOBJS} Makefile
 	${CXX} ${CXXFLAGS} -o $@ ${CXXOBJS} ${LDFLAGS}

--- a/README.rst
+++ b/README.rst
@@ -13,20 +13,12 @@ The home of mcnp2cad on the web is https://github.com/svalinn/mcnp2cad
 This tool is based on an concept first developed at Argonne National
 Laboratory.
 
-Prerequisites:
---------------
-
-The Armadillo (http://arma.sourceforge.net/) linear algebra library is now required as part of suport for GQ/SQ surfaces.
-
-Armadillo is supported on various platforms. Instructions for installation can be found at http://arma.sourceforge.net/download.html.
-
-
 Compiling (with CGM):
 ---------------------
 
-At present CGM_BASE_DIR must be specifed as a make paramter, e.g.
+At present CGM_BASE_DIR and ARMADILLO_BASE_DIR must be specifed as make paramters, e.g.
 
-    make CGM_BASE_DIR=<path to CGM>
+    make CGM_BASE_DIR=<path to CGM> ARMADILLO_BASE_DIR=<path to ARMADILLO>
 
 CGM_BASE_DIR must point to a valid installation of the CGM library.  Information and instructions
 for getting and using CGM are available at 
@@ -38,6 +30,13 @@ LD_LIBRARY_PATH environment variable.  If your version of CGM was compiled
 against CUBIT, you  will likely need to set LD_LIBRARY_PATH as follows:
 
     export LD_LIBRARY_PATH=/path/to/cubit13.1/bin 
+
+ARMADILLO_BASE_DIR must point to a valid installation of the Armadillo
+linear algebra library as part of support for GQ/SQ surfaces.
+Armadillo is supported on various platforms. Instructions for
+installation can be found at http://arma.sourceforge.net/download.html.
+(The default value of Armadillo's installation directory is /usr/local but
+this may vary platform to platform or for manually built installations.)
 
 Running:
 ---------

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+
 MCNP2CAD README
 ===============
 
@@ -11,6 +12,14 @@ The home of mcnp2cad on the web is https://github.com/svalinn/mcnp2cad
 
 This tool is based on an concept first developed at Argonne National
 Laboratory.
+
+Prerequisites:
+--------------
+
+The Armadillo (http://arma.sourceforge.net/) linear algebra library is now required as part of suport for GQ/SQ surfaces.
+
+Armadillo is supported on various platforms. Instructions for installation can be found at http://arma.sourceforge.net/download.html.
+
 
 Compiling (with CGM):
 ---------------------
@@ -73,7 +82,7 @@ Unsupported Features:
      many possible contexts
 
 * Could be added with substantial effort:
-   * General support for `SQ`, `GQ`, `X`, `Y`, and `Z` surfaces.  
+   * General support for `SQ`, `GQ`, `X`, `Y`, and `Z` surfaces. (Elliptic Cylinders and Elliptic Cones currently supported.)
      (Simple `X`, `Y`, `Z` surfaces are already supported.)
    * Robust error detection and reporting for ill-formed MCNP inputs.
 


### PR DESCRIPTION
Adding the Armadillo prerequisite in the Docs. Also indicated what GQs are currently supported (just the two that were required for the JET model right now).