### PR TITLE
Trcl translation fix

### DIFF
--- a/geometry.cpp
+++ b/geometry.cpp
@@ -24,11 +24,6 @@ void Transform::modify_translation( const Vector3d& translation_addition ) {
   return;
 }
 
-// void Transform::modify_translation( const Vector3d& translation_addition ) const {
-//   translation = translation + translation_addition;
-//   return;
-// }
-
 /**
  * Compute Euler axis/angle, given a rotation matix.
  * See en.wikipedia.org/wiki/Rotation_representation_(mathematics) 

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -19,6 +19,16 @@ double matrix_det( double mat[9] ){
           mat[2]*mat[4]*mat[6]);
 }
 
+void Transform::modify_translation( const Vector3d& translation_addition ) {
+  translation = translation + translation_addition;
+  return;
+}
+
+// void Transform::modify_translation( const Vector3d& translation_addition ) const {
+//   translation = translation + translation_addition;
+//   return;
+// }
+
 /**
  * Compute Euler axis/angle, given a rotation matix.
  * See en.wikipedia.org/wiki/Rotation_representation_(mathematics) 

--- a/geometry.hpp
+++ b/geometry.hpp
@@ -43,6 +43,13 @@ public:
     v[2] = p.at(idx+2);
   }
 
+
+  Vector3d( const Vector3d& other ) {
+    v[0] = other.v[0];
+    v[1] = other.v[1];
+    v[2] = other.v[2];
+  }
+  
   double length() const{
     return sqrt( v[0]*v[0] + v[1]*v[1] + v[2]*v[2] );
   }
@@ -52,6 +59,13 @@ public:
     return Vector3d( v[0]/length, v[1]/length, v[2]/length );
   }
 
+  Vector3d& operator=( const Vector3d& other) {
+    v[0] = other.v[0];
+    v[1] = other.v[1];
+    v[2] = other.v[2];
+    return *this;
+  }
+  
   Vector3d operator-() const {
     return Vector3d(-v[0], -v[1], -v[2]);
   }
@@ -131,6 +145,8 @@ public:
   Transform( double rot[9], const Vector3d& trans,  enum mat_format = C_STYLE );
 
   const Vector3d& getTranslation() const { return translation; }
+  void modify_translation( const Vector3d& translation_addition );
+  void modify_translation( const Vector3d& translation_addition ) const;
   bool hasRot() const{ return has_rot; }
   bool hasInversion() const{ return invert; }
   double getTheta() const { return theta; }

--- a/mcnp2cad.cpp
+++ b/mcnp2cad.cpp
@@ -1033,6 +1033,13 @@ bool GeometryContext::defineLatticeNode(  CellCard& cell, iBase_EntityHandle cel
   iGeom_copyEnt( igm, cell_shell, &cell_copy, &igm_result );
   CHECK_IGEOM( igm_result, "Copying a lattice cell shell" );
   cell_copy = applyTransform( t, igm, cell_copy );
+
+  // if the containing cell has a transform applied, apply to all lattice nodes
+  // if( cell.getTrcl().hasData() ){
+  //   Transform trcl = cell.getTrcl().getData();
+  //   t.modify_translation(trcl.getTranslation());
+  // }
+    
   
   if( !boundBoxesIntersect( igm, cell_copy, lattice_shell ) ){
     iGeom_deleteEnt( igm, cell_copy, &igm_result);
@@ -1061,10 +1068,28 @@ bool GeometryContext::defineLatticeNode(  CellCard& cell, iBase_EntityHandle cel
   else{
     // this node has an embedded universe
 
+    const Transform* trans = NULL;
+
+    if( fn->hasTransform() ) {
+      trans = &(fn->getTransform());
+    }
+
+    // check for parent cell transformation
+    if( cell.getTrcl().hasData() ) {
+      Transform trcl = cell.getTrcl().getData();
+      if( trans ) {
+	Vector3d temp = trcl.getTranslation();
+	trans->modify_translation( temp  );
+      }
+      else {
+	trans = &(trcl);
+      }
+    }
+    
     iBase_EntityHandle cell_copy_unmoved;
     iGeom_copyEnt( igm, cell_shell, &cell_copy_unmoved, &igm_result );
     CHECK_IGEOM( igm_result, "Re-copying a lattice cell shell" );
-    node_subcells = defineUniverse(  fn->getFillingUniverse(), cell_copy_unmoved, (fn->hasTransform() ? &(fn->getTransform()) : NULL ) );
+    node_subcells = defineUniverse(  fn->getFillingUniverse(), cell_copy_unmoved, trans );
     for( size_t i = 0; i < node_subcells.size(); ++i ){
       node_subcells[i] = applyTransform( t, igm, node_subcells[i] );
     }

--- a/mcnp2cad.cpp
+++ b/mcnp2cad.cpp
@@ -1033,13 +1033,6 @@ bool GeometryContext::defineLatticeNode(  CellCard& cell, iBase_EntityHandle cel
   iGeom_copyEnt( igm, cell_shell, &cell_copy, &igm_result );
   CHECK_IGEOM( igm_result, "Copying a lattice cell shell" );
   cell_copy = applyTransform( t, igm, cell_copy );
-
-  // if the containing cell has a transform applied, apply to all lattice nodes
-  // if( cell.getTrcl().hasData() ){
-  //   Transform trcl = cell.getTrcl().getData();
-  //   t.modify_translation(trcl.getTranslation());
-  // }
-    
   
   if( !boundBoxesIntersect( igm, cell_copy, lattice_shell ) ){
     iGeom_deleteEnt( igm, cell_copy, &igm_result);


### PR DESCRIPTION
This PR contains a fix for translations applied via the `trcl` keyword for cells filled with universe lattices. Several examples of such cases can be found in #40 

Underlying translations for the lattice did not include this translation and therefore were being incorrectly clipped by the bounds of the universe cell after the `trcl` translation is applied.