### PR TITLE
Adding check for standalone project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ endif()
 
 # These directories need to be defined by the user.
 include_directories(${IGEOM_INCLUDE_DIR})
-find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_LIB_DIR})
+
+# only require iGeom if this project is being built as a standalone
+if(${PROJECT_SOURCE_DIR} EQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+  find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_LIB_DIR})
+endif()
 
 SET(LIB_SRC
     mcnp2cad.cpp


### PR DESCRIPTION
This PR adds a check to determine if mcnp2cad is being built as standalone or as part of another project (the DAGMC-Trelis plugin). This should fix the problem we're seeing with having to run make and cmake more than once when building the importer.