### PR TITLE
Define libiGeom as a dependency of libmcnp2cad if part of a larger pr…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ include_directories(${IGEOM_INCLUDE_DIR})
 # only require iGeom if this project is being built as a standalone
 if(${PROJECT_SOURCE_DIR} EQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_LIB_DIR})
+else()
+  # if this is part of another project
+  # iGeom sould be set as a native CMake dependency
+  set(IGEOM_LIB iGeom)
 endif()
 
 SET(LIB_SRC


### PR DESCRIPTION
This fixes a bug I introduced in #43. 

The if block here doesn't set `IGEOM_LIB` at all if mcnp2cad is part of a bigger project, so the iGeom library won't be linked (unless you were testing the previous change on in a directory with cached CMake variables like a fool...). 

This PR addresses that problem by adding iGeom as a dependency of the mcnp2cad library by default. If the project is being configured as a standalone, an external iGeom library must be found.