### PR TITLE
Rewrite CMake for robustness as both standalone library and part of Trelis plugin

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,7 +1,10 @@
 The following individuals have made contributions to the mcnp2cad project.
 
+* Elliott Biondo
 * Andrew Davis
 * Steve Jackson
+* Lucas Jacobson
 * Patrick Shriwise
+* Samuel Stern
 * Ellis Wilson
 * Paul P.H. Wilson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,51 +2,87 @@ project(libMCNP2CAD)
 
 cmake_minimum_required(VERSION 2.8)
 
-set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -DHAVE_IGEOM_CONE" )
+# Build options
+option(BUILD_MCNP2CAD_TESTS "Build mcnp2cad tests" ON)
 
-# adjust compiler setting for Linux using gcc version 5.0 and higher
-if(CMAKE_SYSTEM_NAME MATCHES Linux AND CMAKE_COMPILER_IS_GNUCXX)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.0")
-    if(NOT CMAKE_CXX_FLAGS MATCHES _GLIBCXX_USE_CXX11_ABI)
+# Default to a release build
+if (NOT CMAKE_BUILD_TYPE)
+  message(STATUS "CMAKE_BUILD_TYPE not specified, defaulting to Release")
+  set(CMAKE_BUILD_TYPE Release)
+endif ()
+  
+# Use C++11
+set(CMAKE_CXX_STANDARD 11)
+
+add_definitions(-DHAVE_IGEOM_CONE=ON)
+
+# Adjust compiler setting for Linux using gcc version 5.0 and higher
+if (CMAKE_SYSTEM_NAME MATCHES Linux AND CMAKE_COMPILER_IS_GNUCXX)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.0")
+    if (NOT CMAKE_CXX_FLAGS MATCHES _GLIBCXX_USE_CXX11_ABI)
       set(CMAKE_CXX_FLAGS "-D_GLIBCXX_USE_CXX11_ABI=0 ${CMAKE_CXX_FLAGS}")
-    endif()
-  endif()
-endif()
+    endif ()
+  endif ()
+endif ()
 
-if(${BUILD_CLI})
-    add_subdirectory(${CMAKE_SOURCE_DIR}/cli)
-endif()
+if (BUILD_CLI)
+  add_subdirectory(cli)
+endif ()
 
-find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+# IGEOM_DIR must be specified if mcnp2cad is being built as a standalone
+# library. If it is not specified, then CMake will assume that mcnp2cad is being
+# built as a part of a larger project which already knows the location of iGeom.
+if (IGEOM_DIR)
+  message(STATUS "Building standalone mcnp2cad")
+  set(STANDALONE ON)
+  include_directories(${IGEOM_DIR}/include)
+  find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_DIR}/lib)
+  get_filename_component(IGEOM_LIB_DIR ${IGEOM_LIB} DIRECTORY)
+  link_directories(${IGEOM_LIB_DIR})
+  message(STATUS "IGEOM_LIB_DIR: ${IGEOM_LIB_DIR}")
+else ()
+  set(STANDALONE OFF)
+endif ()
 
-# These directories need to be defined by the user.
-include_directories(${IGEOM_INCLUDE_DIR})
-find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_LIB_DIR})
+# RPATH handling. If CMAKE_INSTALL_RPATH_USE_LINK_PATH is set to ON, then all
+# directories that have been linked via the link_directories() command will be
+# added to the RPATH.
+if (STANDALONE)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+endif ()
 
-SET(LIB_SRC
-    mcnp2cad.cpp
-    mcnp2cad.hpp
-    MCNPInput.cpp
-    MCNPInput.hpp
-    geometry.cpp
-    geometry.hpp
-    volumes.cpp
-    volumes.hpp
-    GQ_Characterize.cpp
-    GQ_Characterize.hpp
-    test_GQ.cpp
-)
+SET(MCNP2CAD_SRC_FILES geometry.cpp
+                       GQ_Characterize.cpp
+                       mcnp2cad.cpp
+                       MCNPInput.cpp
+                       volumes.cpp)
 
-add_library(mcnp2cad SHARED ${LIB_SRC})
-target_link_libraries(mcnp2cad ${IGEOM_LIB})
+set(MCNP2CAD_PUB_HEADERS dataref.hpp
+                         geometry.hpp
+                         GQ_Characterize.hpp
+                         mcnp2cad.hpp
+                         MCNPInput.hpp
+                         options.hpp
+                         version.hpp
+                         volumes.hpp)
 
-add_executable(test_GQ test_GQ.cpp GQ_Characterize.cpp)
-target_link_libraries(test_GQ)
-if(IGEOM_LIB_DIR)
-    set_target_properties(test_GQ PROPERTIES INSTALL_RPATH ${IGEOM_LIB_DIR} BUILD_WITH_INSTALL_RPATH TRUE)
-elseif(CMAKE_PREFIX_PATH)
-    set_target_properties(test_GQ PROPERTIES INSTALL_RPATH ${CMAKE_PREFIX_PATH} BUILD_WITH_INSTALL_RPATH TRUE)
-endif()
+# mcnp2cad library
+add_library(mcnp2cad SHARED ${MCNP2CAD_SRC_FILES})
+set_target_properties(mcnp2cad PROPERTIES PUBLIC_HEADER
+                      "${MCNP2CAD_PUB_HEADERS}")
+target_link_libraries(mcnp2cad iGeom)
+if (STANDALONE)
+  set(INSTALL_INCLUDE_DIR include)
+else ()
+  set(INSTALL_INCLUDE_DIR include/mcnp2cad)
+endif ()
+install(TARGETS mcnp2cad LIBRARY DESTINATION lib
+        PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR})
 
-enable_testing()
-add_test(NAME test_gq_characterization COMMAND test_GQ)
+# GQ tests
+if (BUILD_MCNP2CAD_TESTS)
+  add_executable(test_GQ test_GQ.cpp GQ_Characterize.cpp)
+  target_link_libraries(test_GQ)
+  add_test(NAME test_gq_characterization COMMAND test_GQ)
+  enable_testing()
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,6 @@ if (CMAKE_SYSTEM_NAME MATCHES Linux AND CMAKE_COMPILER_IS_GNUCXX)
   endif ()
 endif ()
 
-# Build CLI if building standalone
-if (STANDALONE_MCNP2CAD)
-  message(STATUS "Building mcnp2cad CLI")
-  add_subdirectory(cli)
-endif ()
-
 # Find iGeom. If mcnp2cad is being built as a standalone library, then
 # -DIGEOM_DIR must be specified. If it is not being built as a standalone
 # library, then it is assumed that the location of the iGeom library is known
@@ -98,4 +92,10 @@ if (BUILD_MCNP2CAD_TESTS)
   target_link_libraries(test_GQ)
   add_test(NAME test_gq_characterization COMMAND test_GQ)
   enable_testing()
+endif ()
+
+# Build CLI if building standalone
+if (STANDALONE_MCNP2CAD)
+  message(STATUS "Building mcnp2cad CLI")
+  add_subdirectory(cli)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(libMCNP2CAD)
 cmake_minimum_required(VERSION 2.8)
 
 # Build options
-option(BUILD_MCNP2CAD_TESTS "Build mcnp2cad tests" ON)
+option(STANDALONE_MCNP2CAD  "Build mcnp2cad as a standalone program" ON)
+option(BUILD_MCNP2CAD_TESTS "Build mcnp2cad tests"                   ON)
 
 # Default to a release build
 if (NOT CMAKE_BUILD_TYPE)
@@ -14,6 +15,7 @@ endif ()
 # Use C++11
 set(CMAKE_CXX_STANDARD 11)
 
+# iGeom assumed to have cone functionality
 add_definitions(-DHAVE_IGEOM_CONE=ON)
 
 # Adjust compiler setting for Linux using gcc version 5.0 and higher
@@ -25,29 +27,42 @@ if (CMAKE_SYSTEM_NAME MATCHES Linux AND CMAKE_COMPILER_IS_GNUCXX)
   endif ()
 endif ()
 
-if (BUILD_CLI)
+# Build CLI if building standalone
+if (STANDALONE_MCNP2CAD)
+  message(STATUS "Building mcnp2cad CLI")
   add_subdirectory(cli)
 endif ()
 
-# IGEOM_DIR must be specified if mcnp2cad is being built as a standalone
-# library. If it is not specified, then CMake will assume that mcnp2cad is being
-# built as a part of a larger project which already knows the location of iGeom.
-if (IGEOM_DIR)
-  message(STATUS "Building standalone mcnp2cad")
-  set(STANDALONE ON)
+# Find iGeom. If mcnp2cad is being built as a standalone library, then
+# -DIGEOM_DIR must be specified. If it is not being built as a standalone
+# library, then it is assumed that the location of the iGeom library is known
+# and that the iGeom headers have already been included.
+if (STANDALONE_MCNP2CAD)
+  if (NOT IGEOM_DIR)
+    message(FATAL_ERROR "-DIGEOM_DIR must be specified when building mcnp2cad"
+                        " as a standalone library")
+  else ()
+    message(STATUS "Building standalone mcnp2cad")
+  endif ()
+
+  # Find location of iGeom headers
+  find_path(IGEOM_INCLUDE_DIR NAMES iGeom.h HINTS ${IGEOM_DIR}/include)
   include_directories(${IGEOM_DIR}/include)
+  message(STATUS "IGEOM_INCLUDE_DIR: ${IGEOM_INCLUDE_DIR}")
+
+  # Find location of iGeom library
   find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_DIR}/lib)
   get_filename_component(IGEOM_LIB_DIR ${IGEOM_LIB} DIRECTORY)
   link_directories(${IGEOM_LIB_DIR})
   message(STATUS "IGEOM_LIB_DIR: ${IGEOM_LIB_DIR}")
 else ()
-  set(STANDALONE OFF)
+  message(STATUS "Building mcnp2cad as a component of another package")
 endif ()
 
 # RPATH handling. If CMAKE_INSTALL_RPATH_USE_LINK_PATH is set to ON, then all
 # directories that have been linked via the link_directories() command will be
 # added to the RPATH.
-if (STANDALONE)
+if (STANDALONE_MCNP2CAD)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
 endif ()
 
@@ -68,16 +83,14 @@ set(MCNP2CAD_PUB_HEADERS dataref.hpp
 
 # mcnp2cad library
 add_library(mcnp2cad SHARED ${MCNP2CAD_SRC_FILES})
-set_target_properties(mcnp2cad PROPERTIES PUBLIC_HEADER
-                      "${MCNP2CAD_PUB_HEADERS}")
 target_link_libraries(mcnp2cad iGeom)
-if (STANDALONE)
-  set(INSTALL_INCLUDE_DIR include)
-else ()
-  set(INSTALL_INCLUDE_DIR include/mcnp2cad)
+if (STANDALONE_MCNP2CAD)
+  # Only install public headers if building standalone
+  set_target_properties(mcnp2cad PROPERTIES PUBLIC_HEADER
+                        "${MCNP2CAD_PUB_HEADERS}")
 endif ()
 install(TARGETS mcnp2cad LIBRARY DESTINATION lib
-        PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR})
+        PUBLIC_HEADER DESTINATION include)
 
 # GQ tests
 if (BUILD_MCNP2CAD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,21 +39,21 @@ if (STANDALONE_MCNP2CAD)
     message(STATUS "Building standalone mcnp2cad")
   endif ()
 
-  # Create an imported target for iGeom
-  add_library(iGeom SHARED IMPORTED)
-
-  # Find location of iGeom headers and add info to imported target
+  # Find location of iGeom headers
   find_path(IGEOM_INCLUDE_DIR NAMES iGeom.h HINTS ${IGEOM_DIR}/include)
-  target_include_directories(iGeom INTERFACE "${IGEOM_INCLUDE_DIR}")
   message(STATUS "IGEOM_INCLUDE_DIR: ${IGEOM_INCLUDE_DIR}")
 
-  # Find location of iGeom library and add info to imported target
+  # Find location of iGeom library
   find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_DIR}/lib)
   get_filename_component(IGEOM_LIB_DIR ${IGEOM_LIB} DIRECTORY)
-  set_target_properties(iGeom PROPERTIES IMPORTED_LOCATION "${IGEOM_LIB}")
-  target_link_directories(iGeom INTERFACE "${IGEOM_LIB_DIR}")
   message(STATUS "IGEOM_LIB_DIR: ${IGEOM_LIB_DIR}")
   message(STATUS "IGEOM_LIB: ${IGEOM_LIB}")
+
+  # Create an imported target for iGeom
+  add_library(iGeom SHARED IMPORTED)
+  set_target_properties(iGeom PROPERTIES IMPORTED_LOCATION "${IGEOM_LIB}"
+                        INTERFACE_INCLUDE_DIRECTORIES "${IGEOM_INCLUDE_DIR}"
+                        INTERFACE_LINK_DIRECTORIES "${IGEOM_LIB_DIR}")
 else ()
   message(STATUS "Building mcnp2cad as a component of another package."
                  " The iGeom target should already exist.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (STANDALONE_MCNP2CAD)
 
   # Find location of iGeom headers
   find_path(IGEOM_INCLUDE_DIR NAMES iGeom.h HINTS ${IGEOM_DIR}/include)
-  include_directories(${IGEOM_DIR}/include)
+  include_directories(${IGEOM_INCLUDE_DIR})
   message(STATUS "IGEOM_INCLUDE_DIR: ${IGEOM_INCLUDE_DIR}")
 
   # Find location of iGeom library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if (STANDALONE_MCNP2CAD)
   message(STATUS "IGEOM_LIB_DIR: ${IGEOM_LIB_DIR}")
 else ()
   message(STATUS "Building mcnp2cad as a component of another package."
-                 " IGEOM_LIB should already be set.")
+                 " iGeom target should already exist.")
 endif ()
 
 # RPATH handling. If CMAKE_INSTALL_RPATH_USE_LINK_PATH is set to ON, then all
@@ -78,7 +78,7 @@ set(MCNP2CAD_PUB_HEADERS dataref.hpp
 
 # mcnp2cad library
 add_library(mcnp2cad SHARED ${MCNP2CAD_SRC_FILES})
-target_link_libraries(mcnp2cad ${IGEOM_LIB})
+target_link_libraries(mcnp2cad iGeom)
 if (STANDALONE_MCNP2CAD)
   # Only install public headers if building standalone
   set_target_properties(mcnp2cad PROPERTIES PUBLIC_HEADER

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,17 +39,19 @@ if (STANDALONE_MCNP2CAD)
     message(STATUS "Building standalone mcnp2cad")
   endif ()
 
-  # Find location of iGeom headers
+  # Create an imported target for iGeom
+  add_library(iGeom SHARED IMPORTED)
+
+  # Find location of iGeom headers and add info to imported target
   find_path(IGEOM_INCLUDE_DIR NAMES iGeom.h HINTS ${IGEOM_DIR}/include)
-  include_directories(${IGEOM_INCLUDE_DIR})
+  target_include_directories(iGeom INTERFACE "${IGEOM_INCLUDE_DIR}")
   message(STATUS "IGEOM_INCLUDE_DIR: ${IGEOM_INCLUDE_DIR}")
 
-  # Find location of iGeom library and create an imported target for it
+  # Find location of iGeom library and add info to imported target
   find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_DIR}/lib)
   get_filename_component(IGEOM_LIB_DIR ${IGEOM_LIB} DIRECTORY)
-  link_directories(${IGEOM_LIB_DIR})
-  add_library(iGeom SHARED IMPORTED)
   set_target_properties(iGeom PROPERTIES IMPORTED_LOCATION "${IGEOM_LIB}")
+  target_link_directories(iGeom INTERFACE "${IGEOM_LIB_DIR}")
   message(STATUS "IGEOM_LIB_DIR: ${IGEOM_LIB_DIR}")
   message(STATUS "IGEOM_LIB: ${IGEOM_LIB}")
 else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,21 +44,31 @@ if (STANDALONE_MCNP2CAD)
   include_directories(${IGEOM_INCLUDE_DIR})
   message(STATUS "IGEOM_INCLUDE_DIR: ${IGEOM_INCLUDE_DIR}")
 
-  # Find location of iGeom library
+  # Find location of iGeom library and create an imported target for it
   find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_DIR}/lib)
   get_filename_component(IGEOM_LIB_DIR ${IGEOM_LIB} DIRECTORY)
   link_directories(${IGEOM_LIB_DIR})
+  add_library(iGeom SHARED IMPORTED)
+  set_target_properties(iGeom PROPERTIES IMPORTED_LOCATION "${IGEOM_LIB}")
   message(STATUS "IGEOM_LIB_DIR: ${IGEOM_LIB_DIR}")
+  message(STATUS "IGEOM_LIB: ${IGEOM_LIB}")
 else ()
   message(STATUS "Building mcnp2cad as a component of another package."
-                 " iGeom target should already exist.")
+                 " The iGeom target should already exist.")
 endif ()
 
-# RPATH handling. If CMAKE_INSTALL_RPATH_USE_LINK_PATH is set to ON, then all
-# directories that have been linked via the link_directories() command will be
-# added to the RPATH.
+# RPATH handling
 if (STANDALONE_MCNP2CAD)
+  # Add all directories that have been linked via the link_directories() command
+  # to the RPATH
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+  # Add the location of libraries installed by this project to the
+  # INSTALL_RPATH_DIRS variable
+  if (CMAKE_INSTALL_RPATH)
+    set(INSTALL_RPATH_DIRS "${CMAKE_INSTALL_RPATH}:${CMAKE_INSTALL_PREFIX}/lib")
+  else ()
+    set(INSTALL_RPATH_DIRS "${CMAKE_INSTALL_PREFIX}/lib")
+  endif ()
 endif ()
 
 SET(MCNP2CAD_SRC_FILES geometry.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(libMCNP2CAD)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 # Build options
 option(STANDALONE_MCNP2CAD  "Build mcnp2cad as a standalone program" ON)
@@ -26,6 +26,11 @@ if (CMAKE_SYSTEM_NAME MATCHES Linux AND CMAKE_COMPILER_IS_GNUCXX)
     endif ()
   endif ()
 endif ()
+
+# Find Eigen3
+find_package(Eigen3 3.3 REQUIRED)
+message(STATUS "EIGEN3_INCLUDE_DIR: ${EIGEN3_INCLUDE_DIR}")
+include_directories(${EIGEN3_INCLUDE_DIR})
 
 # Find iGeom. If mcnp2cad is being built as a standalone library, then
 # -DIGEOM_DIR must be specified. If it is not being built as a standalone

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,6 @@ install(TARGETS mcnp2cad LIBRARY DESTINATION lib
 # GQ tests
 if (BUILD_MCNP2CAD_TESTS)
   add_executable(test_GQ test_GQ.cpp GQ_Characterize.cpp)
-  target_link_libraries(test_GQ)
   add_test(NAME test_gq_characterization COMMAND test_GQ)
   enable_testing()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ if (STANDALONE_MCNP2CAD)
   link_directories(${IGEOM_LIB_DIR})
   message(STATUS "IGEOM_LIB_DIR: ${IGEOM_LIB_DIR}")
 else ()
-  message(STATUS "Building mcnp2cad as a component of another package")
+  message(STATUS "Building mcnp2cad as a component of another package."
+                 " IGEOM_LIB should already be set.")
 endif ()
 
 # RPATH handling. If CMAKE_INSTALL_RPATH_USE_LINK_PATH is set to ON, then all
@@ -77,7 +78,7 @@ set(MCNP2CAD_PUB_HEADERS dataref.hpp
 
 # mcnp2cad library
 add_library(mcnp2cad SHARED ${MCNP2CAD_SRC_FILES})
-target_link_libraries(mcnp2cad iGeom)
+target_link_libraries(mcnp2cad ${IGEOM_LIB})
 if (STANDALONE_MCNP2CAD)
   # Only install public headers if building standalone
   set_target_properties(mcnp2cad PROPERTIES PUBLIC_HEADER

--- a/GQ_Characterize.cpp
+++ b/GQ_Characterize.cpp
@@ -1,4 +1,4 @@
-#include <eigen3/Eigen/Eigen>
+#include <Eigen/Eigen>
 #include <cfloat>
 #include <iostream>
 #include "GQ_Characterize.hpp"

--- a/GQ_Characterize.hpp
+++ b/GQ_Characterize.hpp
@@ -1,7 +1,7 @@
 #ifndef GQ_CHARACTERIZE_H
 #define GQ_CHARACTERIZE_H
 
-#include <eigen3/Eigen/Eigen>
+#include <Eigen/Eigen>
 #include <cfloat>
 #include <iostream>
 #include <string>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2017, University of Wisconsin-Madison
+Copyright (c) 2011-2020, University of Wisconsin-Madison
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -5,7 +5,6 @@ SET(CLI_SRC_FILES mcnp2cadex.cpp
                   ProgOptions.hpp)
 
 add_definitions(-DUSE_CLI=ON)
-#link_directories("/opt/Trelis-16.5/bin")
 add_executable(convertMCNP ${CLI_SRC_FILES})
 target_link_libraries(convertMCNP mcnp2cad)
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -7,5 +7,6 @@ SET(CLI_SRC_FILES mcnp2cadex.cpp
 add_definitions(-DUSE_CLI=ON)
 add_executable(convertMCNP ${CLI_SRC_FILES})
 target_link_libraries(convertMCNP mcnp2cad)
+install(TARGETS convertMCNP DESTINATION bin)
 
 # CLI inherits rpath functionality from mcnp2cad library

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -7,6 +7,6 @@ SET(CLI_SRC_FILES mcnp2cadex.cpp
 add_definitions(-DUSE_CLI=ON)
 add_executable(convertMCNP ${CLI_SRC_FILES})
 target_link_libraries(convertMCNP mcnp2cad)
+set_target_properties(convertMCNP PROPERTIES
+                      INSTALL_RPATH "${INSTALL_RPATH_DIRS}")
 install(TARGETS convertMCNP DESTINATION bin)
-
-# CLI inherits rpath functionality from mcnp2cad library

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -1,15 +1,12 @@
 # Create the mcnp2cad commandline executable, convertMCNP.
 
-SET(CLI_SRC
-    mcnp2cadex.cpp
-    ProgOptions.cpp
-    ProgOptions.hpp)
+SET(CLI_SRC_FILES mcnp2cadex.cpp
+                  ProgOptions.cpp
+                  ProgOptions.hpp)
 
-add_definitions(-DUSE_CLI)
-add_executable(convertMCNP ${CLI_SRC})
+add_definitions(-DUSE_CLI=ON)
+#link_directories("/opt/Trelis-16.5/bin")
+add_executable(convertMCNP ${CLI_SRC_FILES})
 target_link_libraries(convertMCNP mcnp2cad)
-if(IGEOM_LIB_DIR)
-    set_target_properties(convertMCNP PROPERTIES INSTALL_RPATH ${IGEOM_LIB_DIR} BUILD_WITH_INSTALL_RPATH TRUE)
-elseif(CMAKE_PREFIX_PATH)
-    set_target_properties(convertMCNP PROPERTIES INSTALL_RPATH ${CMAKE_PREFIX_PATH} BUILD_WITH_INSTALL_RPATH TRUE)
-endif()
+
+# CLI inherits rpath functionality from mcnp2cad library

--- a/geometry.cpp
+++ b/geometry.cpp
@@ -5,7 +5,7 @@
 
 #include "mcnp2cad.hpp"
 #include "options.hpp"
-#include <eigen3/Eigen/Eigen>
+#include <Eigen/Eigen>
 
 std::ostream& operator<<(std::ostream& str, const Vector3d& v ){
   str << "(" << v.v[0] << ", " << v.v[1] << ", " << v.v[2] << ")";


### PR DESCRIPTION
This is a companion PR to https://github.com/svalinn/Trelis-plugin/pull/56.