### PR TITLE
Check to see if IGEOM_LIB target exists before searching.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,10 @@ endif()
 find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 # These directories need to be defined by the user.
-include_directories(${IGEOM_INCLUDE_DIR})
-find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_LIB_DIR})
+if(NOT TAGRGET IGEOM_LIB)
+  include_directories(${IGEOM_INCLUDE_DIR})
+  find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_LIB_DIR})
+endif()
 
 SET(LIB_SRC
     mcnp2cad.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 # These directories need to be defined by the user.
-if(NOT TAGRGET IGEOM_LIB)
+if(NOT TARGET IGEOM_LIB)
   include_directories(${IGEOM_INCLUDE_DIR})
   find_library(IGEOM_LIB NAMES iGeom HINTS ${IGEOM_LIB_DIR})
 endif()


### PR DESCRIPTION

Small change here to check for the `IGEOM_LIB` target before searching for it. Because mcnp2cad is sometimes used as a component in the [Trelis plugin for DAGMC](https://github.com/svalinn/trelis-plugin), this target may already exist.